### PR TITLE
Uri escape roles

### DIFF
--- a/lib/scout/command.rb
+++ b/lib/scout/command.rb
@@ -170,7 +170,7 @@ module Scout
     end
 
     def initialize(options, args)
-      @roles   = options[:roles]
+      @roles   = parse_roles( options[:roles] )
       @server  = options[:server]  || "https://server.pingdom.com/"
       @history = options[:history] ||
                  File.join( File.join( (File.expand_path("~") rescue "/"),
@@ -236,6 +236,24 @@ module Scout
     def usage
       @usage ||= Command.usage
     end
+
+    def parse_roles(roles='')
+      roles.split(",").each { |role|
+        newrole = sanitize_role_name( role )
+        newroles.push( newrole )
+
+        if newrole != role
+          log.warn "Role \"#{role}\" is not properly sanitized. Will be used as role \"#{newrole}\"." if log
+        end
+      }
+
+      @roles = newroles
+    end
+
+    def sanitize_role_name(role='')
+      role.downcase.gsub(/ /, '_').gsub(/[^a-z0-9:._-]/, '')
+    end
+
 
     def create_pid_file_or_exit
       pid_file = File.join(config_dir, "scout_client_pid.txt")

--- a/lib/scout/server.rb
+++ b/lib/scout/server.rb
@@ -63,7 +63,7 @@ module Scout
     def refresh?
       return true if !ping_key or account_public_key_changed? # fetch the plan again if the account key is modified/created
 
-      url=URI.join( @server.sub("https://","http://"), "/clients/#{ping_key}/ping.scout?roles=#{@roles}&hostname=#{URI.encode(@hostname)}&env=#{URI.encode(@environment)}")
+      url=URI.join( @server.sub("https://","http://"), "/clients/#{ping_key}/ping.scout?roles=#{URI.encode(@roles)}&hostname=#{URI.encode(@hostname)}&env=#{URI.encode(@environment)}")
 
       headers = {"x-scout-tty" => ($stdin.tty? ? 'true' : 'false')}
       if @history["plan_last_modified"] and @history["old_plugins"]

--- a/lib/scout/server_base.rb
+++ b/lib/scout/server_base.rb
@@ -30,7 +30,7 @@ module Scout
                "/clients/CLIENT_KEY/#{url_name}.scout".
                    gsub(/\bCLIENT_KEY\b/, @client_key).
                    gsub(/\b[A-Z_]+\b/) { |k| options[k.downcase.to_sym] || k })
-      uri.query = ["roles=#{@roles}","hostname=#{URI.encode(@hostname)}","env=#{URI.encode(@environment)}","tty=#{$stdin.tty? ? 'y' : 'n'}"].join('&')
+      uri.query = ["roles=#{URI.encode(@roles)}","hostname=#{URI.encode(@hostname)}","env=#{URI.encode(@environment)}","tty=#{$stdin.tty? ? 'y' : 'n'}"].join('&')
       uri
     end
 


### PR DESCRIPTION
URI escape the roles parameter so that an invalid character in a role (which can be read from the disk) doesn't stop the client from reporting. E.g. a white space in a role name causes the URL to be invalid and the client fails to connect.